### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,4 @@ updates:
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "weekly"
+      interval: "daily"


### PR DESCRIPTION
This pull request includes a small change to the `.github/dependabot.yml` file. The change updates the schedule interval for dependency updates from weekly to daily.

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L11-R11): Changed the `interval` for the `npm` package-ecosystem from "weekly" to "daily".